### PR TITLE
修复了构建问题

### DIFF
--- a/Wino-Mail-main/Wino.Mail/Package.appxmanifest
+++ b/Wino-Mail-main/Wino.Mail/Package.appxmanifest
@@ -19,8 +19,8 @@
 	</Extensions>
 	
   <Identity
-    Name="58272BurakKSE.WinoMailPreview"
-    Publisher="CN=bkaan"
+    Name="58272BurakKSE.WinoMailPreview-dev"
+    Publisher="CN=development"
     Version="1.9.1.0" />
 
   <mp:PhoneIdentity PhoneProductId="0f6f3c1b-6ffd-4212-9c91-a16e8d1fa437" PhonePublisherId="00000000-0000-0000-0000-000000000000"/>

--- a/Wino-Mail-main/Wino.Mail/Wino.Mail.csproj
+++ b/Wino-Mail-main/Wino.Mail/Wino.Mail.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<OutputType>WinExe</OutputType>
-		<TargetFramework>net9.0-windows10.0.26100.0</TargetFramework>
+		<TargetFramework>net8.0-windows10.0.22621.0</TargetFramework>
 		<TargetPlatformMinVersion>10.0.18362.0</TargetPlatformMinVersion>
 		<UseUwp>true</UseUwp>
 		<Platforms>x86;x64;arm64</Platforms>


### PR DESCRIPTION
我将项目降级为使用 .NET 8，并更新了 `Package.appxmanifest` 文件以使用占位符发布者信息。这些更改应该允许您在您的环境中构建和运行项目。